### PR TITLE
Fix TypeError: hasattr(): attribute name must be string

### DIFF
--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -81,7 +81,7 @@ def get_modules_info():
     for (mod, name, version_attr) in Modules:
         if not fileutil.has_module(mod):
             continue
-        if hasattr(mod, version_attr):
+        if version_attr and hasattr(mod, version_attr):
             attr = getattr(mod, version_attr)
             version = attr() if callable(attr) else attr
             module_infos.append("%s %s" % (name, version))


### PR DESCRIPTION
The one test failure in Travis happens in TestConsole.test_internal_error, but only if you have the argcomplete package installed.

This was a real bug in error reporting code.

Fixes #7.