### PR TITLE
Add install_requires for setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -479,6 +479,9 @@ args = dict(
     options = {
     },
     # Requirements, usable with setuptools or the new Python packaging module.
+    install_requires = [
+        'requests >= 2.2.0',
+    ],
     # Commented out since they are untested and not officially supported.
     # See also doc/install.txt for more detailed dependency documentation.
     #extra_requires = {


### PR DESCRIPTION
This makes 'pip install' install everything that's needed for
LinkChecker to actually work.

Fixes #12.