### PR TITLE
Force header names to lower to allow for CaseInsensitiveDict variability

### DIFF
--- a/linkcheck/plugins/httpheaderinfo.py
+++ b/linkcheck/plugins/httpheaderinfo.py
@@ -36,8 +36,8 @@ class HttpHeaderInfo(_ConnectionPlugin):
         """Check content for invalid anchors."""
         headers = []
         for name, value in url_data.headers.items():
-            if name.startswith(self.prefixes):
-                headers.append(name)
+            if name.lower().startswith(self.prefixes):
+                headers.append(name.lower())
         if headers:
             items = [u"%s=%s" % (name.capitalize(), url_data.headers[name]) for name in headers]
             info = u"HTTP headers %s" % u", ".join(items)


### PR DESCRIPTION
This is a trivial fix for the old issue 690 (https://github.com/wummel/linkchecker/issues/690) The problem is caused by a change in the behaviour of CaseInsensitiveDict from the requests library. In some versions this returns lower-cased keys, in others mixed case.