### PR TITLE
Fix incompatible pointer type warnings

### DIFF
--- a/linkcheck/HtmlParser/htmlparse.c
+++ b/linkcheck/HtmlParser/htmlparse.c
@@ -102,7 +102,7 @@ extern int yyget_lineno(void*);
 #define YYERROR_VERBOSE 1
 
 /* standard error reporting, indicating an internal error */
-static void yyerror (YYSTYPE *locp, char const *msg) {
+static void yyerror (void *locp, char const *msg) {
     fprintf(stderr, "htmlsax: internal parse error: %s\n", msg);
 }
 

--- a/linkcheck/HtmlParser/htmlparse.y
+++ b/linkcheck/HtmlParser/htmlparse.y
@@ -37,7 +37,7 @@ extern int yyget_lineno(void*);
 #define YYERROR_VERBOSE 1
 
 /* standard error reporting, indicating an internal error */
-static void yyerror (YYSTYPE *locp, char const *msg) {
+static void yyerror (void *locp, char const *msg) {
     fprintf(stderr, "htmlsax: internal parse error: %s\n", msg);
 }
 


### PR DESCRIPTION
The warnings looked like this:

    htmlparse.c: In function ‘yyparse’:
    htmlparse.c:1810:18: warning: passing argument 1 of ‘yyerror’ from incompatible pointer type [-Wincompatible-pointer-types]
    htmlparse.y:40:13: note: expected ‘PyObject ** {aka struct _object **}’ but argument is of type ‘PyObject * {aka struct _object *}’
    htmlparse.c:1927:12: warning: passing argument 1 of ‘yyerror’ from incompatible pointer type [-Wincompatible-pointer-types]
    htmlparse.y:40:13: note: expected ‘PyObject ** {aka struct _object **}’ but argument is of type ‘PyObject * {aka struct _object *}’

The argument is not used, so it doesn't really matter what pointer type
it is.

Fixes #34.