### PR TITLE
Avoid info log 'Checking intern URLs only…' when calling 'linkchecker --version'

### DIFF
--- a/linkchecker
+++ b/linkchecker
@@ -425,6 +425,8 @@ if options.debug and not __debug__:
 # apply commandline options and arguments to configuration
 constructauth = False
 do_profile = False
+if options.version:
+    print_version()
 if not options.warnings:
     config["warnings"] = options.warnings
 if options.externstrict:
@@ -523,8 +525,6 @@ if options.timeout is not None:
     else:
         print_usage(_("Illegal argument %(arg)r for option %(option)s") % \
                     {"arg": options.timeout, "option": "'--timeout'"})
-if options.version:
-    print_version()
 if options.listplugins:
     print_plugins(config["pluginfolders"])
 if options.verbose:


### PR DESCRIPTION
Current output:
```
$ linkchecker --version
INFO linkcheck.cmdline 2017-09-11 12:46:55,167 MainThread Checking intern URLs only; use --check-extern to check extern URLs.
LinkChecker 9.4 released xx.xx.xxxx
Copyright (C) 2000-2014 Bastian Kleineidam
```
Please note: I have not tested this very minor change proposal, just used github web ui for editing etc, but I mean what should go wrong ;-)