### PR TITLE
use xdg dirs for config & data

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -5,6 +5,7 @@ Features:
   Closes: GH bug #532
 - checking: Support XDG Base Directory Specification for configuration
   and data.
+  Closes: GH bug #44
 
 Changes:
 - installation: Remove dependency on msgfmt.py by pre-generating the

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -3,6 +3,8 @@
 Features:
 - checking: Support itms-services: URLs.
   Closes: GH bug #532
+- checking: Support XDG Base Directory Specification for configuration
+  and data.
 
 Changes:
 - installation: Remove dependency on msgfmt.py by pre-generating the

--- a/linkcheck/bookmarks/chrome.py
+++ b/linkcheck/bookmarks/chrome.py
@@ -17,6 +17,7 @@
 
 import os
 import sys
+from xdg import xdg_config_home
 
 # Windows filename encoding
 nt_filename_encoding="mbcs"
@@ -40,7 +41,7 @@ def get_profile_dir ():
         if sys.platform == 'darwin':
             dirpath = os.path.join(basedir, u"Library", u"Application Support")
         else:
-            dirpath = os.path.join(basedir, u".config")
+            dirpath = xdg_config_home
         dirpath = os.path.join(dirpath, u"Google", u"Chrome")
     return dirpath
 

--- a/linkcheck/bookmarks/chromium.py
+++ b/linkcheck/bookmarks/chromium.py
@@ -18,6 +18,7 @@
 import os
 import sys
 import json
+from xdg import xdg_config_home
 
 
 # Windows filename encoding
@@ -42,7 +43,7 @@ def get_profile_dir ():
         if sys.platform == 'darwin':
             dirpath = os.path.join(basedir, u"Library", u"Application Support")
         else:
-            dirpath = os.path.join(basedir, u".config")
+            dirpath = xdg_config_home
         dirpath = os.path.join(dirpath, u"chromium")
     return dirpath
 

--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -365,13 +365,22 @@ class Configuration (dict):
                         pass
 
 
+def get_user_data():
+    """Get the user data folder.
+    Returns "~/.linkchecker/" if this folder exists, \
+    "$XDG_DATA_HOME/linkchecker" if it does not.
+    @rtype string
+    """
+    homedotdir = normpath("~/.linkchecker/")
+    userdata = homedotdir if os.path.isdir(homedotdir) \
+        else os.path.join(xdg_data_home, "linkchecker")
+    return userdata
+
 def get_plugin_folders():
     """Get linkchecker plugin folders. Default is
     $XDG_DATA_HOME/linkchecker/plugins/."""
     folders = []
-    homedotfilefolder = normpath("~/.linkchecker/plugins")
-    defaultfolder = homedotfilefolder if os.path.isdir(homedotfilefolder) \
-        else os.path.join(xdg_data_home, "linkchecker", "plugins")
+    defaultfolder = os.path.join(get_user_data(), "plugins")
     if not os.path.exists(defaultfolder) and not Portable:
         try:
             make_userdir(defaultfolder)

--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -378,7 +378,9 @@ def get_user_data():
 
 def get_plugin_folders():
     """Get linkchecker plugin folders. Default is
-    $XDG_DATA_HOME/linkchecker/plugins/."""
+    "$XDG_DATA_HOME/linkchecker/plugins/". "~/.linkchecker/plugins/" is also
+    supported for backwards compatibility, and is used if both directories
+    exist."""
     folders = []
     defaultfolder = os.path.join(get_user_data(), "plugins")
     if not os.path.exists(defaultfolder) and not Portable:

--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -32,6 +32,7 @@ import _LinkChecker_configdata as configdata
 from .. import (log, LOG_CHECK, get_install_data, fileutil)
 from . import confparse
 from ..decorators import memoized
+from xdg.BaseDirectory import xdg_config_home, xdg_data_home
 
 Version = configdata.version
 ReleaseDate = configdata.release_date
@@ -365,9 +366,12 @@ class Configuration (dict):
 
 
 def get_plugin_folders():
-    """Get linkchecker plugin folders. Default is ~/.linkchecker/plugins/."""
+    """Get linkchecker plugin folders. Default is
+    $XDG_DATA_HOME/linkchecker/plugins/."""
     folders = []
-    defaultfolder = normpath("~/.linkchecker/plugins")
+    homedotfilefolder = normpath("~/.linkchecker/plugins")
+    defaultfolder = homedotfilefolder if os.path.isdir(homedotfilefolder) \
+        else os.path.join(xdg_data_home, "linkchecker", "plugins")
     if not os.path.exists(defaultfolder) and not Portable:
         try:
             make_userdir(defaultfolder)
@@ -403,7 +407,9 @@ def get_user_config():
     # initial config (with all options explained)
     initialconf = normpath(os.path.join(get_share_dir(), "linkcheckerrc"))
     # per user config settings
-    userconf = normpath("~/.linkchecker/linkcheckerrc")
+    homedotfile = normpath("~/.linkchecker/linkcheckerrc")
+    userconf = homedotfile if os.path.isfile(homedotfile) \
+        else os.path.join(xdg_config_home, "linkchecker", "linkcheckerrc")
     if os.path.isfile(initialconf) and not os.path.exists(userconf) and \
        not Portable:
         # copy the initial configuration to the user configuration

--- a/linkcheck/logger/blacklist.py
+++ b/linkcheck/logger/blacklist.py
@@ -20,7 +20,7 @@ A blacklist logger.
 
 import os
 import codecs
-from xdg.BaseDirectory import xdg_data_home
+from linkcheck.configuration import get_user_data
 from . import _Logger
 
 
@@ -34,7 +34,7 @@ class BlacklistLogger (_Logger):
     LoggerName = "blacklist"
 
     LoggerArgs = {
-        "filename": os.path.join(xdg_data_home, "linkchecker", "blacklist"),
+        "filename": os.path.join(get_user_data(), "blacklist"),
     }
 
     def __init__ (self, **kwargs):

--- a/linkcheck/logger/blacklist.py
+++ b/linkcheck/logger/blacklist.py
@@ -20,6 +20,7 @@ A blacklist logger.
 
 import os
 import codecs
+from xdg.BaseDirectory import xdg_data_home
 from . import _Logger
 
 
@@ -33,7 +34,7 @@ class BlacklistLogger (_Logger):
     LoggerName = "blacklist"
 
     LoggerArgs = {
-        "filename": "~/.linkchecker/blacklist",
+        "filename": os.path.join(xdg_data_home, "linkchecker", "blacklist"),
     }
 
     def __init__ (self, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # required:
 requests<2.15,>=2.2
-xdg
+pyxdg
 # optional:
 argcomplete

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # required:
 requests<2.15,>=2.2
+xdg
 # optional:
 argcomplete

--- a/setup.py
+++ b/setup.py
@@ -481,7 +481,7 @@ args = dict(
     # Requirements, usable with setuptools or the new Python packaging module.
     install_requires = [
         'requests<2.15,>=2.2',
-        'xdg',
+        'pyxdg',
     ],
     # Commented out since they are untested and not officially supported.
     # See also doc/install.txt for more detailed dependency documentation.

--- a/setup.py
+++ b/setup.py
@@ -481,6 +481,7 @@ args = dict(
     # Requirements, usable with setuptools or the new Python packaging module.
     install_requires = [
         'requests<2.15,>=2.2',
+        'xdg',
     ],
     # Commented out since they are untested and not officially supported.
     # See also doc/install.txt for more detailed dependency documentation.


### PR DESCRIPTION
~/.linkchecker is used instead of the xdg equivalents if the directory
exists (backward compatibility).