### PR TITLE
Document missing python 3 compatibility; Fixes #88

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Features
 Installation
 -------------
 See doc/install.txt in the source code archive.
-Python 2.7.2 or later is needed.
+Python 2.7.2 or later is needed. It doesn't work with Python 3 yet, see `#40 <https://github.com/linkcheck/linkchecker/pull/40>`_ for details.
 
 Usage
 ------


### PR DESCRIPTION
In accordance to the review of #89, I've created a commit with only the python 3 compatibility note. 