### PR TITLE
Fix fragment identifier quoting

### DIFF
--- a/linkcheck/url.py
+++ b/linkcheck/url.py
@@ -338,7 +338,7 @@ def url_norm (url, encoding=None):
     urlparts[2] = url_quote_part(urlparts[2], safechars=_nopathquote_chars, encoding=encoding) # path
     if not urlparts[0].startswith("feed"):
         urlparts[2] = url_fix_wayback_query(urlparts[2]) # unencode colon in http[s]:// in wayback path
-    urlparts[4] = url_quote_part(urlparts[4], encoding=encoding) # anchor
+    urlparts[4] = url_quote_part(urlparts[4], safechars="!$&'()*+,-./;=?@_~", encoding=encoding) # anchor
     res = urlunsplit(urlparts)
     if url.endswith('#') and not urlparts[4]:
         # re-append trailing empty fragment

--- a/tests/checker/data/http.html.result
+++ b/tests/checker/data/http.html.result
@@ -67,7 +67,7 @@ valid
 
 url http://example.org/foo/ #a=1,2,3
 cache key http://example.org/foo/%%20
-real url http://example.org/foo/%%20#a%%3D1%%2C2%%2C3
+real url http://example.org/foo/%%20#a=1,2,3
 error
 
 url http://.example.org/

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -172,14 +172,16 @@ class TestUrl (unittest.TestCase):
         nurl = "http://example.com:81/"
         self.urlnormtest(url, nurl)
 
-    def test_norm_fragment (self):
+    def test_norm_fragment_empty (self):
         # Test url norm fragment preserving.
         # Empty fragment identifiers must be preserved:
         url = "http://www.w3.org/2000/01/rdf-schema#"
         nurl = url
         self.urlnormtest(url, nurl)
+
+    def test_norm_fragment (self):
         url = "http://example.org/foo/ #a=1,2,3"
-        nurl = "http://example.org/foo/%20#a%3D1%2C2%2C3"
+        nurl = "http://example.org/foo/%20#a=1,2,3"
         self.urlnormtest(url, nurl)
 
     def test_norm_empty_path (self):


### PR DESCRIPTION
According to <https://tools.ietf.org/html/rfc3986>:

    fragment    = *( pchar / "/" / "?" )
    pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
    unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
    pct-encoded = "%" HEXDIG HEXDIG
    sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="

Fixes #96