### PR TITLE
Do not fail to mkdir ~/.local/share/linkchecker/plugins when ~/.local/share is missing

### DIFF
--- a/linkcheck/configuration/__init__.py
+++ b/linkcheck/configuration/__init__.py
@@ -403,7 +403,7 @@ def make_userdir(child):
             # Windows forbids filenames with leading dot unless
             # a trailing dot is added.
             userdir += "."
-        os.mkdir(userdir, 0700)
+        os.makedirs(userdir, 0700)
 
 
 def get_user_config():


### PR DESCRIPTION
See  https://github.com/linkcheck/linkchecker/issues/115 ("linkchecker --version" leads to warning log)

=> Use os.makedirs(...) instead of os.mkdir(...)