### PR TITLE
update .travis.yml to test in Pyhon3 in allow-failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: python
 python:
   - "2.7"
-# whitelist of git branches to build
-branches:
-  only:
-    - master
+  - "3.5"
+  - "3.6"
 # command to install dependencies
 install:
   - pip install tox-travis coveralls
@@ -16,3 +14,7 @@ notifications:
   email: false
 after_script:
   - coveralls
+matrix:
+   allow_failures:
+      - python: "3.5"
+      - python: "3.6"


### PR DESCRIPTION
Test in Python 3 versions in allow-failures mode (as a prerequisite for porting to porting).
Test on all branches (because it is quite annoying in development process).