### PR TITLE
Test for linenumbers and other parts of url_data

### DIFF
--- a/tests/checker/__init__.py
+++ b/tests/checker/__init__.py
@@ -39,12 +39,24 @@ class TestLogger (linkcheck.logger._Logger):
 
     LoggerName = 'test'
 
+    logparts = [
+        'cachekey',
+        'realurl',
+        'name',
+        'base',
+        'info',
+        'warning',
+        'result',
+        'url',
+    ]
+
     def __init__ (self, **kwargs):
         """
         The kwargs must have "expected" keyword with the expected logger
         output lines.
         """
         args = self.get_args(kwargs)
+        args['parts'] = self.logparts
         super(TestLogger, self).__init__(**args)
         # list of expected output lines
         self.expected = args['expected']
@@ -86,6 +98,20 @@ class TestLogger (linkcheck.logger._Logger):
                 self.result.append(u"warning %s" % warning)
         if self.has_part('result'):
             self.result.append(u"valid" if url_data.valid else u"error")
+        if self.has_part('line'):
+            self.result.append(u"line %s" % url_data.line)
+        if self.has_part('col'):
+            self.result.append(u"col %s" % url_data.column)
+        if self.has_part('size'):
+            self.result.append(u"size %s" % url_data.size)
+        if self.has_part('parent_url'):
+            self.result.append(u"parent_url %s" % url_data.parent_url)
+        if self.has_part('page'):
+            self.result.append(u"page %s" % url_data.page)
+        if self.has_part('modified'):
+            self.result.append(u"modified %s" % url_data.modified)
+        if self.has_part('content_type'):
+            self.result.append(u"content_type %s" % url_data.content_type)
         # note: do not append url_data.result since this is
         # platform dependent
 
@@ -119,12 +145,12 @@ def add_fileoutput_config (config):
         config['fileoutput'].append(logger)
 
 
-def get_test_aggregate (confargs, logargs):
+def get_test_aggregate (confargs, logargs, logger=TestLogger):
     """Initialize a test configuration object."""
     config = linkcheck.configuration.Configuration()
-    config.logger_add(TestLogger)
+    config.logger_add(logger)
     config['recursionlevel'] = 1
-    config['logger'] = config.logger_new(TestLogger.LoggerName, **logargs)
+    config['logger'] = config.logger_new(logger.LoggerName, **logargs)
     add_fileoutput_config(config)
     # uncomment for debugging
     #config.init_logging(None, debug=["all"])
@@ -141,6 +167,7 @@ class LinkCheckTest (unittest.TestCase):
     """
     Functional test class with ability to test local files.
     """
+    logger = TestLogger
 
     def setUp (self):
         """Ensure the current locale setting is the default.
@@ -189,7 +216,7 @@ class LinkCheckTest (unittest.TestCase):
         if confargs is None:
             confargs = {}
         logargs = {'expected': self.get_resultlines(filename)}
-        aggregate = get_test_aggregate(confargs, logargs)
+        aggregate = get_test_aggregate(confargs, logargs, logger=self.logger)
         url_data = get_url_from(url, 0, aggregate, extern=(0, 0))
         aggregate.urlqueue.put(url_data)
         linkcheck.director.check_urls(aggregate)

--- a/tests/checker/data/all_parts.html
+++ b/tests/checker/data/all_parts.html
@@ -1,0 +1,8 @@
+<!-- base without href -->
+<base target="_top">
+<!-- meta url -->
+<META HTTP-equiv="refresh" content="0; url=base2.html">
+<!-- spaces between key and value -->
+<a href 
+=
+"file.html">

--- a/tests/checker/data/all_parts.html.result
+++ b/tests/checker/data/all_parts.html.result
@@ -1,0 +1,33 @@
+url file://%(curdir)s/%(datadir)s/all_parts.html
+cache key file://%(curdir)s/%(datadir)s/all_parts.html
+real url file://%(curdir)s/%(datadir)s/all_parts.html
+name %(datadir)s/all_parts.html
+valid
+line 0
+col 0
+size 184
+parent_url 
+page 0
+
+content_type text/html
+url base2.html
+cache key file://%(curdir)s/%(datadir)s/base2.html
+real url file://%(curdir)s/%(datadir)s/base2.html
+valid
+line 4
+col 1
+size 64
+parent_url file://%(curdir)s/%(datadir)s/all_parts.html
+page 0
+content_type text/html
+
+url file.html
+cache key file://%(curdir)s/%(datadir)s/file.html
+real url file://%(curdir)s/%(datadir)s/file.html
+valid
+line 6
+col 1
+size 115
+parent_url file://%(curdir)s/%(datadir)s/all_parts.html
+page 0
+content_type text/html

--- a/tests/checker/test_all_parts.py
+++ b/tests/checker/test_all_parts.py
@@ -1,0 +1,50 @@
+# -*- coding: iso-8859-1 -*-
+# Copyright (C) 2004-2014 Bastian Kleineidam
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Test http checking.
+"""
+from . import LinkCheckTest
+import __init__ as init
+
+
+class AllPartsLogger(init.TestLogger):
+    logparts = [
+        'cachekey',
+        'realurl',
+        'name',
+        'base',
+        'info',
+        'warning',
+        'result',
+        'url',
+        'line',
+        'col',
+        'size',
+        'parent_url',
+        'page',
+        'content_type',
+    ]
+
+
+class TestAllParts(LinkCheckTest):
+    """
+    Test that all parts of logger are working properly.
+    """
+    logger = AllPartsLogger
+
+    def test_all_parts(self):
+        self.file_test("all_parts.html")


### PR DESCRIPTION
This adds a test for various parts of `url_data` variable in `Logger`.

I am not sure, if this works on all platforms.