### PR TITLE
Fix internal error when using cookies

### DIFF
--- a/linkcheck/director/aggregator.py
+++ b/linkcheck/director/aggregator.py
@@ -34,6 +34,7 @@ from .. import log, LOG_CHECK, strformat, LinkCheckerError
 from ..decorators import synchronized
 from ..cache import urlqueue
 from ..htmlutil import formsearch
+from ..cookies import from_file
 from . import logger, status, checker, interrupt
 
 
@@ -51,7 +52,7 @@ def new_request_session(config, cookies):
         "User-Agent": config["useragent"],
     })
     if config["cookiefile"]:
-        for cookie in cookies.from_file(config["cookiefile"]):
+        for cookie in from_file(config["cookiefile"]):
             session.cookies = requests.cookies.merge_cookies(session.cookies, cookie)
     return session
 

--- a/tests/cookies.txt
+++ b/tests/cookies.txt
@@ -1,0 +1,3 @@
+Host: example.org
+Path: /hello
+Set-cookie: om="nomnom"

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -18,8 +18,12 @@
 Test cookie routines.
 """
 
+import os
 import unittest
+
 import linkcheck.cookies
+import linkcheck.configuration
+import linkcheck.director
 
 
 class TestCookies (unittest.TestCase):
@@ -66,3 +70,10 @@ class TestCookies (unittest.TestCase):
         ]
         from_headers = linkcheck.cookies.from_headers
         self.assertRaises(ValueError, from_headers, "\r\n".join(lines))
+
+    def test_cookie_file (self):
+        config = linkcheck.configuration.Configuration()
+        here = os.path.dirname(__file__)
+        config['cookiefile'] = os.path.join(here, 'cookies.txt')
+        aggregate = linkcheck.director.get_aggregate(config)
+        aggregate.add_request_session()


### PR DESCRIPTION
There was some kind of confusion between a module and a function argument, introduced in commit 90257a1b5ed552ba015e74fa40dca052e17d1f38.  As far as I can tell, the `cookies` parameter passed to `new_request_session()` is supposed to be a `cookielib.CookieJar()` instance, which has no `from_file()` method.

Fixes #62.

I would prefer to write a regression test for this before merging.  I'm not sure I'll manage that in a reasonable time interval, and it's probably better to fix the bug without a regression test than to leave the bug unfixed, so, @anarcat, feel free to merge this in a couple of days if there are no indications of progress.

(TBH I would prefer if somebody else wrote a regression test, but I don't think that's likely.)

(FWIW writing about how I'm unlikely to do X is my way of motivating myself to do X.  I don't know how effective it is, but it's worked in the past.)