### PR TITLE
Load cookies from the --cookiefile correctly

### DIFF
--- a/linkcheck/cookies.py
+++ b/linkcheck/cookies.py
@@ -42,12 +42,12 @@ def from_file (filename):
             line = line.rstrip()
             if not line:
                 if lines:
-                    entries.append(from_headers("\r\n".join(lines)))
+                    entries.extend(from_headers("\r\n".join(lines)))
                 lines = []
             else:
                 lines.append(line)
         if lines:
-            entries.append(from_headers("\r\n".join(lines)))
+            entries.extend(from_headers("\r\n".join(lines)))
         return entries
 
 
@@ -63,7 +63,9 @@ def from_headers (strheader):
     if "Host" not in headers:
         raise ValueError("Required header 'Host:' missing")
     host = headers["Host"]
-    path= headers.get("Path", "/")
+    # XXX: our --help says we also pay attention to the Scheme: header,
+    # but we don't?!
+    path = headers.get("Path", "/")
     for header in headers.getallmatchingheaders("Set-Cookie"):
         headervalue = header.split(':', 1)[1]
         for pairs in split_header_words([headervalue]):

--- a/linkcheck/director/aggregator.py
+++ b/linkcheck/director/aggregator.py
@@ -53,7 +53,7 @@ def new_request_session(config, cookies):
     })
     if config["cookiefile"]:
         for cookie in from_file(config["cookiefile"]):
-            session.cookies = requests.cookies.merge_cookies(session.cookies, cookie)
+            session.cookies.set_cookie(cookie)
     return session
 
 

--- a/tests/cookies.txt
+++ b/tests/cookies.txt
@@ -1,3 +1,7 @@
 Host: example.org
 Path: /hello
 Set-cookie: om="nomnom"
+
+Host: example.com
+Set-cookie: multiple=cookies
+Set-cookie: are=allowed

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -72,8 +72,12 @@ class TestCookies (unittest.TestCase):
         self.assertRaises(ValueError, from_headers, "\r\n".join(lines))
 
     def test_cookie_file (self):
+        # Regression test for https://github.com/linkcheck/linkchecker/issues/62
         config = linkcheck.configuration.Configuration()
         here = os.path.dirname(__file__)
         config['cookiefile'] = os.path.join(here, 'cookies.txt')
         aggregate = linkcheck.director.get_aggregate(config)
         aggregate.add_request_session()
+        session = aggregate.get_request_session()
+        self.assertEqual({c.name for c in session.cookies},
+                         {'om', 'multiple', 'are'})


### PR DESCRIPTION
requests.cookies.merge_cookies() requires a dict or a CookieJar as the second argument.  We've been passing lists of Cookie objects instead.

Fixes #62, harder this time.