### PR TITLE
make tests pass on IPv6 hosts

### DIFF
--- a/tests/checker/test_http_misc.py
+++ b/tests/checker/test_http_misc.py
@@ -47,7 +47,12 @@ class TestHttpMisc (HttpServerTest):
         if os.name != "posix" or sys.platform != 'linux2':
             return
         host = "www.heise.de"
-        ip = iputil.resolve_host(host)[0]
+        for tentative_ip in iputil.resolve_host(host):
+            if iputil.is_valid_ipv4(tentative_ip):
+                ip = tentative_ip
+                break
+        else:
+            raise NotImplementedError("no IPv4 address detected for test host")
         url = u"http://%s/" % iputil.obfuscate_ip(ip)
         rurl = u"http://%s/" % ip
         resultlines = [


### PR DESCRIPTION
Without this patch, tests would fail on IPv6 hosts with this
mysterious error:

```
_______________________________________________________________________ TestHttpMisc.test_html ________________________________________________________________________
tests/checker/test_http_misc.py:30: in test_html
    self.obfuscate_test()
tests/checker/test_http_misc.py:51: in obfuscate_test
    url = u"http://%s/" % iputil.obfuscate_ip(ip)
linkcheck/network/iputil.py:290: in obfuscate_ip
    raise ValueError('Invalid IP value %r' % ip)
E   ValueError: Invalid IP value '2a02:2e0:3fe:1001:7777:772e:2:85'
```

As it turns out, the test host (`www.heise.de`) does have an IPv6
record and our tests pass on Travis only because they do not have a
working IPv6 stack. I happen to have IPv6 at home and tests are broken
here, so add a quick workaround so tests pass again.

Ideally, we would not have to deal with this hack and would handle
"obfuscation" correctly, but I have yet to figure out what that test
actually does before fixing it properly.