### PR TITLE
Require requests >= 2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # required:
-requests<2.15,>=2.2
+requests>=2.4
 pyxdg
 dnspython
 # optional:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # required:
-requests>=2.4
+requests<2.15,>=2.4
 pyxdg
 dnspython
 # optional:

--- a/setup.py
+++ b/setup.py
@@ -501,7 +501,7 @@ args = dict(
     },
     # Requirements, usable with setuptools or the new Python packaging module.
     install_requires = [
-        'requests>=2.4',
+        'requests<2.15,>=2.4',
         'dnspython',
         'pyxdg',
     ],

--- a/setup.py
+++ b/setup.py
@@ -501,7 +501,7 @@ args = dict(
     },
     # Requirements, usable with setuptools or the new Python packaging module.
     install_requires = [
-        'requests<2.15,>=2.2',
+        'requests>=2.4',
         'dnspython',
         'pyxdg',
     ],


### PR DESCRIPTION
This is already in the code in `linkcheck/__init__.py`, update the requirements and setup file so it can be installed via `pip`.